### PR TITLE
feat(intellisense): add citation hover metadata display

### DIFF
--- a/src/intellisense/citationHoverProvider.ts
+++ b/src/intellisense/citationHoverProvider.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import { IntellisenseProvider } from '.';
+import { RemoteFileSystemProvider } from '../core/remoteFileSystemProvider';
+import { TexDocumentSymbolProvider } from './texDocumentSymbolProvider';
+import { CitationMetadata, parseBibContent } from './citationMetadata';
+
+export class CitationHoverProvider extends IntellisenseProvider implements vscode.HoverProvider {
+    protected readonly contextPrefix = [];
+
+    constructor(
+        vfsm: RemoteFileSystemProvider,
+        private readonly texSymbolProvider: TexDocumentSymbolProvider,
+    ) {
+        super(vfsm);
+    }
+
+    private findCitationKeyAtPosition(document: vscode.TextDocument, position: vscode.Position): string | undefined {
+        const line = document.lineAt(position.line);
+        const lineText = line.text;
+        const targetOffset = position.character;
+        const citationRegex = /\\(?:cite\w*|\w*cite)(?:\[[^\]]*\])*\{([^}]*)\}/g;
+
+        let match: RegExpExecArray | null;
+        while ((match = citationRegex.exec(lineText))) {
+            const full = match[0];
+            const keysRaw = match[1] ?? '';
+            const keysStart = match.index + full.lastIndexOf('{') + 1;
+            const keysEnd = keysStart + keysRaw.length;
+            if (targetOffset < keysStart || targetOffset > keysEnd) {
+                continue;
+            }
+
+            let cursor = 0;
+            const parts = keysRaw.split(',');
+            for (const part of parts) {
+                const leadingSpaces = part.match(/^\s*/)?.[0].length ?? 0;
+                const trailingSpaces = part.match(/\s*$/)?.[0].length ?? 0;
+                const keyStart = cursor + leadingSpaces;
+                const keyEnd = cursor + part.length - trailingSpaces;
+                if (targetOffset >= keysStart + keyStart && targetOffset <= keysStart + keyEnd) {
+                    const key = part.trim();
+                    return key === '' ? undefined : key;
+                }
+                cursor += part.length + 1;
+            }
+        }
+
+        return undefined;
+    }
+
+    private formatHover(entry: CitationMetadata): vscode.Hover {
+        const escapeMarkdown = (value: string) => value.replace(/[\\`*_{}\[\]()#+\-.!|>]/g, '\\$&');
+        const markdown = new vscode.MarkdownString();
+        const title = entry.title ?? entry.key;
+        markdown.appendMarkdown(`### ${escapeMarkdown(title)}\n\n`);
+        if (entry.author) {
+            markdown.appendMarkdown(`**Authors**: ${escapeMarkdown(entry.author)}  \n`);
+        }
+        if (entry.year) {
+            markdown.appendMarkdown(`**Year**: ${escapeMarkdown(entry.year)}  \n`);
+        }
+        if (entry.journal ?? entry.booktitle) {
+            markdown.appendMarkdown(`**Venue**: *${escapeMarkdown(entry.journal ?? entry.booktitle ?? '')}*  \n`);
+        }
+        markdown.appendMarkdown(`\n---\nKey: \`${escapeMarkdown(entry.key)}\``);
+        return new vscode.Hover(markdown);
+    }
+
+    private async getCitationMetadata(uri: vscode.Uri, citationKey: string): Promise<CitationMetadata | undefined> {
+        const vfs = await this.vfsm.prefetch(uri);
+        for (const path of this.texSymbolProvider.currentBibPathArray) {
+            try {
+                const raw = await vfs.openFile(vfs.pathToUri(path));
+                const entries = parseBibContent(new TextDecoder().decode(raw));
+                const found = entries.find(entry => entry.key === citationKey);
+                if (found) {
+                    return found;
+                }
+            } catch {
+                continue;
+            }
+        }
+        return undefined;
+    }
+
+    async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover | undefined> {
+        const citationKey = this.findCitationKeyAtPosition(document, position);
+        if (!citationKey) {
+            return undefined;
+        }
+
+        const metadata = await this.getCitationMetadata(document.uri, citationKey);
+        if (!metadata) {
+            return undefined;
+        }
+
+        return this.formatHover(metadata);
+    }
+
+    get triggers(): vscode.Disposable[] {
+        return [
+            vscode.languages.registerHoverProvider(this.selector, this),
+        ];
+    }
+}

--- a/src/intellisense/citationMetadata.ts
+++ b/src/intellisense/citationMetadata.ts
@@ -1,0 +1,97 @@
+export type CitationMetadata = {
+    key: string;
+    title?: string;
+    author?: string;
+    year?: string;
+    journal?: string;
+    booktitle?: string;
+};
+
+const entryStartRegex = /@(?:(?!STRING\b)[^{])+\{\s*([^},]+),/gim;
+
+function findMatchingBrace(content: string, openBraceIndex: number): number {
+    let depth = 0;
+    for (let i = openBraceIndex; i < content.length; i++) {
+        const ch = content[i];
+        if (ch === '{') {
+            depth += 1;
+        } else if (ch === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+function normalizeFieldValue(rawValue: string): string {
+    // Normalize BibTeX formatting for UI display.
+    // This strips capitalization/grouping braces (e.g. {C}omprehensive -> Comprehensive)
+    // and unescapes a few common escaped characters.
+    const normalized = rawValue
+        .replace(/[{}]/g, '')
+        .replace(/\\&/g, '&')
+        .replace(/\\_/g, '_')
+        .replace(/\\%/g, '%')
+        .replace(/\\#/g, '#')
+        .replace(/[\r\n\t]+/g, ' ')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+    return normalized;
+}
+
+function extractField(entryBody: string, fieldName: string): string | undefined {
+    const regex = new RegExp(`(?:^|,)\\s*${fieldName}\\s*=\\s*(\\{(?:[^{}]|\\{[^{}]*\\})*\\}|\"[^\"]*\")`, 'im');
+    const match = regex.exec(entryBody);
+    if (!match) {
+        return undefined;
+    }
+
+    let value = match[1].trim();
+    if ((value.startsWith('{') && value.endsWith('}')) || (value.startsWith('"') && value.endsWith('"'))) {
+        value = value.slice(1, -1);
+    }
+    value = normalizeFieldValue(value);
+    return value === '' ? undefined : value;
+}
+
+export function parseBibContent(content: string): CitationMetadata[] {
+    const entries: CitationMetadata[] = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = entryStartRegex.exec(content))) {
+        const key = match[1]?.trim();
+        if (!key) {
+            continue;
+        }
+
+        const openBraceIndex = content.indexOf('{', match.index);
+        if (openBraceIndex < 0) {
+            continue;
+        }
+        const closeBraceIndex = findMatchingBrace(content, openBraceIndex);
+        if (closeBraceIndex < 0) {
+            continue;
+        }
+
+        const entryBody = content.slice(openBraceIndex + 1, closeBraceIndex);
+        const firstCommaIndex = entryBody.indexOf(',');
+        if (firstCommaIndex < 0) {
+            entries.push({ key });
+            continue;
+        }
+
+        const fieldBody = entryBody.slice(firstCommaIndex + 1);
+        entries.push({
+            key,
+            title: extractField(fieldBody, 'title'),
+            author: extractField(fieldBody, 'author'),
+            year: extractField(fieldBody, 'year'),
+            journal: extractField(fieldBody, 'journal'),
+            booktitle: extractField(fieldBody, 'booktitle'),
+        });
+    }
+
+    return entries;
+}

--- a/src/intellisense/langCompletionProvider.ts
+++ b/src/intellisense/langCompletionProvider.ts
@@ -4,6 +4,7 @@ import { SnippetItemSchema } from '../api/base';
 import { fuzzyFilter, IntellisenseProvider } from '.';
 import { RemoteFileSystemProvider, VirtualFileSystem, parseUri } from '../core/remoteFileSystemProvider';
 import { TexDocumentSymbolProvider } from './texDocumentSymbolProvider';
+import { CitationMetadata, parseBibContent } from './citationMetadata';
 
 type SnippetItemMap = {[K:string]: SnippetItemSchema};
 type FilePathCompletionType = 'text' | 'image' | 'bib';
@@ -411,20 +412,43 @@ export class ReferenceCompletionProvider extends IntellisenseProvider implements
     }
 
     private async getReferenceCompletionItemsFromBib(vfs: VirtualFileSystem): Promise<vscode.CompletionItem[]> {
-        const bibRegex = /@(?:(?!STRING\b)[^{])+\{\s*([^},]+)/gm;
         const items = new Array<vscode.CompletionItem>();
         for (const path of this.texSymbolProvider.currentBibPathArray) {
             try{
                 const rawContent = await vfs.openFile( vfs.pathToUri(path) );
                 const content = new TextDecoder().decode(rawContent);
-                let match: RegExpExecArray | null;
-                while (match = bibRegex.exec(content)) {
-                    const item = new vscode.CompletionItem(match[1], vscode.CompletionItemKind.Reference);
-                    items.push(item);
+                const entries = parseBibContent(content);
+                for (const entry of entries) {
+                    items.push(this.createCitationCompletionItem(entry));
                 }
             } catch{}
         };
         return items;
+    }
+
+    private createCitationCompletionItem(entry: CitationMetadata): vscode.CompletionItem {
+        const escapeMarkdown = (value: string) => value.replace(/[\\`*_{}\[\]()#+\-.!|>]/g, '\\$&');
+        const item = new vscode.CompletionItem(entry.key, vscode.CompletionItemKind.Reference);
+        const subtitle = [entry.author, entry.year].filter(Boolean).join(' - ');
+        if (subtitle) {
+            item.detail = subtitle;
+        }
+
+        const markdown = new vscode.MarkdownString();
+        const title = entry.title ?? entry.key;
+        markdown.appendMarkdown(`**${escapeMarkdown(title)}**  \n`);
+        if (entry.author) {
+            markdown.appendMarkdown(`**Authors**: ${escapeMarkdown(entry.author)}  \n`);
+        }
+        if (entry.year) {
+            markdown.appendMarkdown(`**Year**: ${escapeMarkdown(entry.year)}  \n`);
+        }
+        if (entry.journal ?? entry.booktitle) {
+            markdown.appendMarkdown(`**Venue**: *${escapeMarkdown(entry.journal ?? entry.booktitle ?? '')}*  \n`);
+        }
+        markdown.appendMarkdown(`Key: \`${escapeMarkdown(entry.key)}\``);
+        item.documentation = markdown;
+        return item;
     }
 
     private async getReferenceCompletionItemsFromBbl(vfs: VirtualFileSystem): Promise<vscode.CompletionItem[]>{

--- a/src/intellisense/langIntellisenseProvider.ts
+++ b/src/intellisense/langIntellisenseProvider.ts
@@ -7,6 +7,7 @@ import { TexDocumentSymbolProvider } from './texDocumentSymbolProvider';
 import { TexDocumentFormatProvider } from './texDocumentFormatProvider';
 import { MisspellingCheckProvider } from './langMisspellingCheckProvider';
 import { CommandCompletionProvider, ConstantCompletionProvider, FilePathCompletionProvider, ReferenceCompletionProvider } from './langCompletionProvider';
+import { CitationHoverProvider } from './citationHoverProvider';
 
 export class LangIntellisenseProvider {
     private status: vscode.StatusBarItem;
@@ -24,6 +25,7 @@ export class LangIntellisenseProvider {
             new ConstantCompletionProvider(vfsm, context.extensionUri),
             new FilePathCompletionProvider(vfsm),
             new ReferenceCompletionProvider(vfsm, texSymbolProvider),
+            new CitationHoverProvider(vfsm, texSymbolProvider),
             // misspelling check provider
             new MisspellingCheckProvider(vfsm),
         ];


### PR DESCRIPTION
Closes #328

When a user types a citation command such as `\cite{key}`, IntelliSense already shows author/title details from the bibliography. However, once the citation is inserted, there is no way to view that information again without partially retyping the command.

This PR implements a hover provider for citation keys and improves citation completion to display bibliography metadata in both contexts.

**Changes**

- Added `src/intellisense/citationMetadata.ts`: shared BibTeX parser that extracts `key`, `title`, `author`, `year`, `journal`, and `booktitle` from `.bib` files. BibTeX brace-protected capitalization (e.g. `{C}omprehensive`) is normalised for display.
- Added `src/intellisense/citationHoverProvider.ts`: hover provider that detects citation keys under the cursor (including multi-key citations and optional arguments) and shows a Markdown card with bibliography metadata sourced from the project's `.bib` files.
- Updated `src/intellisense/langCompletionProvider.ts`: refactored `ReferenceCompletionProvider` to use the shared parser and attach `detail` (author/year) and structured Markdown `documentation` to each citation completion item.
- Updated `src/intellisense/langIntellisenseProvider.ts`: registered `CitationHoverProvider` alongside existing intellisense providers.