### PR TITLE
fix: improve reconnection stability and fix resource leaks

### DIFF
--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -111,7 +111,7 @@ export class SocketIOAPI {
             const timeoutPromise = new Promise((_, reject) => {
                 setTimeout(() => {
                     reject('timeout');
-                }, 5000);
+                }, 15000);
             });
             const waitPromise = new Promise((resolve, reject) => {
                 this.socket.emit(event, ...args, (err:any, ...data:any[]) => {
@@ -144,7 +144,7 @@ export class SocketIOAPI {
             console.log('SocketIOAPI: connectionRejected.', err.message);
         });
         this.socket.on('error', (err:any) => {
-            throw new Error(err);
+            console.error('SocketIOAPI error:', err);
         });
 
         if (this.scheme==='v2') {
@@ -230,7 +230,10 @@ export class SocketIOAPI {
                     this.socket.on('connectionAccepted', (_:any, publicId:any) => {
                         handler(publicId);
                     });
-                    EventBus.on('socketioConnectedEvent', (arg:{publicId:string}) => {
+                    if (this._busConnAcceptedDisposable) {
+                        this._busConnAcceptedDisposable.dispose();
+                    }
+                    this._busConnAcceptedDisposable = EventBus.on('socketioConnectedEvent', (arg:{publicId:string}) => {
                         handler(arg.publicId);
                     });
                     break;
@@ -292,7 +295,7 @@ export class SocketIOAPI {
         const timeoutPromise: Promise<ProjectEntity> = new Promise((_, reject) => {
             setTimeout(() => {
                 reject('timeout');
-            }, 5000);
+            }, 15000);
         });
 
         switch(this.scheme) {
@@ -305,7 +308,7 @@ export class SocketIOAPI {
                     return project;
                 });
                 const rejectPromise = new Promise((_, reject) => {
-                    this.socket.on('connectionRejected', (err:any) => {
+                    this.socket.once('connectionRejected', (err:any) => {
                         this.scheme = 'v2';
                         reject(err.message);
                     });

--- a/src/collaboration/clientManager.ts
+++ b/src/collaboration/clientManager.ts
@@ -58,15 +58,16 @@ export class ClientManager {
     private readonly status: vscode.StatusBarItem;
     private readonly onlineUsers: {[K:string]:ExtendedUpdateUserSchema} = {};
     private connectedFlag: boolean = true;
+    private _handlers: any;
     private readonly chatViewer: ChatViewProvider;
 
     constructor(
         private readonly vfs: VirtualFileSystem,
         private readonly context: vscode.ExtensionContext,
-        private readonly publicId: string,
-        private readonly socket: SocketIOAPI,
+        private publicId: string,
+        private socket: SocketIOAPI,
     ) {
-        this.socket.updateEventHandlers({
+        this._handlers = {
             onClientUpdated: (user:UpdateUserSchema) => {
                 if (user.id !== this.publicId) { this.setStatusActive(user.id); }
                 this.updatePosition(user.id, user.doc_id, user.row, user.column, user);
@@ -80,7 +81,8 @@ export class ClientManager {
             onConnectionAccepted: (publicId:string) => {
                 this.connectedFlag = true;
             }
-        });
+        };
+        this.socket.updateEventHandlers(this._handlers);
         this.socket.getConnectedUsers().then(users => {
             users.forEach(user => {
                 const onlineUser = {
@@ -103,6 +105,14 @@ export class ClientManager {
         this.chatViewer = new ChatViewProvider(this.vfs, this.publicId, this.context.extensionUri, this.socket);
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
         this.updateStatus();
+    }
+
+    reconnect() {
+        this.socket = this.vfs.socket;
+        this.publicId = this.vfs.publicId || '';
+        this.socket.updateEventHandlers(this._handlers);
+        this.connectedFlag = true;
+        this.onlineUsers = {};
     }
 
     private async jumpToUser(id?: string) {
@@ -248,7 +258,7 @@ export class ClientManager {
                 this.status.tooltip = `${ELEGANT_NAME}: ${vscode.l10n.t('Not connected')}`;
                 // Kick out all users indication since the connection is lost
                 Object.keys(this.onlineUsers).forEach(clientId => {
-                    this.removePosition(clientId);
+                    try { this.removePosition(clientId); } catch (e) { /* vfs may be reconnecting */ }
                 });
                 break;
             case true:

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -204,23 +204,17 @@ export class VirtualFileSystem extends vscode.Disposable {
             this.root = project;
             const activeCondition = (vscode.workspace.workspaceFolders===undefined) || (vscode.workspace.workspaceFolders?.[0].uri.scheme!==ROOT_NAME) || (vscode.workspace.workspaceFolders?.[0].uri===this.origin);
             // Register: [collaboration] ClientManager on Statusbar
-            if (activeCondition) {
-                if (this.clientManagerItem?.triggers) {
-                    this.clientManagerItem.triggers.forEach((trigger) => trigger.dispose());
-                    delete this.clientManagerItem;
-                }
+            if (activeCondition && !this.clientManagerItem) {
                 const clientManager = new ClientManager(this, this.context, this.publicId||'', this.socket);
                 this.clientManagerItem = {
                     manager: clientManager,
                     triggers: clientManager.triggers,
                 };
+            } else if (activeCondition && this.clientManagerItem) {
+                this.clientManagerItem.manager.reconnect();
             }
             // Register: [scm] SCMCollectionProvider in explorer
-            if (activeCondition) {
-                if (this.scmCollectionItem?.triggers) {
-                    this.scmCollectionItem.triggers.forEach((trigger) => trigger.dispose());
-                    delete this.scmCollectionItem;
-                }
+            if (activeCondition && !this.scmCollectionItem) {
                 const scmCollection = new SCMCollectionProvider(this, this.context);
                 this.scmCollectionItem = {
                     collection: scmCollection,
@@ -282,7 +276,7 @@ export class VirtualFileSystem extends vscode.Disposable {
         parentFolder: FolderEntity, fileEntity: FileEntity, fileType:FileType, path:string
     } | undefined {
         if (!this.root) {
-            throw vscode.FileSystemError.FileNotFound();
+            return undefined;
         }
         root = root || this.root.rootFolder[0];
         path = path || '/';


### PR DESCRIPTION
## Summary

Fixes several bugs in the socket reconnection flow that cause crashes, lost file sync operations, and resource leaks. These issues affect all users but are more visible on unstable connections (closes #309).

### Problems

1. **`_resolveById` throws when VFS root is uninitialized** — during reconnect, `this.root` is briefly `undefined`. Any call to `_resolveById` (from `ClientManager.removePosition`, cursor tracking, etc.) throws `EntryNotFound`, crashing the 500ms status timer chain. All callers already handle `undefined` returns via optional chaining.

2. **SCMCollectionProvider destroyed on every reconnect** — `initializingPromise` unconditionally disposes and recreates both `ClientManager` and `SCMCollectionProvider` after each successful `joinProject`. This kills in-progress `LocalReplicaSCMProvider.overwrite()` (file sync), discards file watchers, and resets collaboration state.

3. **`connectionRejected` listener leak in `joinProject`** — uses `.on()` instead of `.once()`, accumulating a new listener on every `joinProject` call. After ~10 reconnects, triggers `MaxListenersExceededWarning`.

4. **`EventBus.on('socketioConnectedEvent')` leak** — `updateEventHandlers` registers a new `EventBus` listener for `onConnectionAccepted` on every call without removing the previous one.

5. **5-second socket emit timeout** — too aggressive for connections with non-trivial latency (proxy, remote servers). `joinDoc` calls frequently time out, cascading into disconnects.

6. **`error` handler throws uncaught exceptions** — `initInternalHandlers` throws on socket errors, which can crash the extension host.

### Changes

| File | Change |
|------|--------|
| `src/core/remoteFileSystemProvider.ts` | `_resolveById` returns `undefined` when root is not set; skip SCM/ClientManager recreation when they already exist |
| `src/collaboration/clientManager.ts` | Add `reconnect()` method to re-register handlers on new socket; save handlers as named object; guard `removePosition` in `updateStatus` forEach |
| `src/api/socketio.ts` | Increase emit/joinProject timeout to 15s; use `.once()` for `connectionRejected`; dispose previous `EventBus` listener before re-registering; log errors instead of throwing |

## Test plan

- [ ] Open a project, verify file sync completes without "Local Replica creation failed"
- [ ] Disconnect and reconnect network, verify status bar recovers and collaboration state is preserved
- [ ] Check developer console for absence of `MaxListenersExceededWarning` and `EntryNotFound` errors
- [ ] Verify real-time collaboration (cursor tracking, user list) works after reconnect