### PR TITLE
fix(local-replica): handle Windows paths when syncing saved documents

### DIFF
--- a/src/scm/localReplicaSCM.ts
+++ b/src/scm/localReplicaSCM.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as DiffMatchPatch from 'diff-match-patch';
+import * as path from 'path';
 import { minimatch } from 'minimatch';
 import { BaseSCM, CommitItem, SettingItem } from ".";
 import { VirtualFileSystem, parseUri } from '../core/remoteFileSystemProvider';
@@ -346,9 +347,24 @@ export class LocalReplicaSCMProvider extends BaseSCM {
      */
     private onDocumentSaved(doc: vscode.TextDocument) {
         const docUri = doc.uri;
-        // Only sync files within our baseUri (ensure path separator boundary)
-        const basePath = this.baseUri.path.endsWith('/') ? this.baseUri.path : this.baseUri.path + '/';
-        if (!docUri.path.startsWith(basePath)) { return; }
+
+        // Check the URI scheme before using fsPath for filesystem path comparison.
+        if (docUri.scheme!=='file' || this.baseUri.scheme!=='file') { return; }
+
+        const basePath = path.resolve(this.baseUri.fsPath);
+        const docPath = path.resolve(docUri.fsPath);
+        const relativePath = path.relative(basePath, docPath);
+
+        // Ignore paths outside the Local Replica directory:
+        if (
+            relativePath==='' // an empty path means the document path is the replica root itself;
+            || relativePath==='..' // ".." means the document path is the parent directory;
+            || relativePath.startsWith(`..${path.sep}`) // "../..." means the document is outside the replica directory;
+            || path.isAbsolute(relativePath) // an absolute result may occur on Windows when the paths are on different drives.
+        ) {
+            return;
+        }
+
         this.syncToVFS(docUri, 'update');
     }
 


### PR DESCRIPTION
Fix (#394) Local Replica uploads on Windows when a document is saved from VS Code.

In v0.15.10, Local Replica synchronization was changed to upload files from `onDidSaveTextDocument` instead of reacting to all filesystem changes. The saved document was then checked using a case-sensitive URI string prefix comparison:

```ts
docUri.path.startsWith(basePath)
````

On Windows, the project URI and document URI may represent the same filesystem path with different drive-letter or path casing. In that case, the prefix check fails and the save event is silently ignored, so `syncToVFS()` is never called.

## Changes

* Use filesystem paths through `Uri.fsPath`.
* Resolve the project and document paths with `path.resolve()`.
* Use `path.relative()` to determine whether the saved document is inside the Local Replica directory.
* Reject non-`file` URIs.
* Reject paths outside the project directory, including sibling directories and paths on another Windows drive.

This preserves the v0.15.10 save-only synchronization behavior. It does not restore filesystem-change uploads, so changes made by Git, compilers, or other external processes are not automatically pushed.

## Testing

* `npm run compile`
* `npm test`
* Packaged and installed the extension locally on Windows 11.
* Opened an Overleaf project using **Open Project Locally**.
* Edited and saved `main.tex` and verified that the change was uploaded to Overleaf.

