### PR TITLE
fix(local-replica): Addresses the external-file-change regression described in #396.

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,6 +430,12 @@
           "scope": "machine",
           "markdownDescription": "%configuration.compileOnSave.enabled.markdownDescription%"
         },
+        "overleaf-workshop.localReplica.syncOnFileChange.enabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "machine",
+          "markdownDescription": "%configuration.localReplica.syncOnFileChange.enabled.markdownDescription%"
+        },
         "overleaf-workshop.compileOutputFolderName": {
           "type": "string",
           "default": ".output",

--- a/package.nls.json
+++ b/package.nls.json
@@ -50,6 +50,7 @@
     "commands.collaboration.jumpToUser.title": "Jump to Collaborator ...",
 
     "configuration.compileOnSave.enabled.markdownDescription": "Always update the compiled PDF when a file is saved.",
+    "configuration.localReplica.syncOnFileChange.enabled.markdownDescription": "Sync Local Replica changes made by external tools. (Take effect after restarting VSCode)",
     "configuration.compileOutputFolderName.markdownDescription": "The name of the folder where the compiled output files (e.g., `output.pdf`) is located. (Take effect after restarting VSCode)",
     "configuration.pdfViewer.themes.markdownDescription": "Configure the color themes used by the PDF viewer. (Take effect after restarting VSCode)",
     "configuration.pdfViewer.themes.theme.description": "The name of the theme.",

--- a/src/scm/localReplicaSCM.ts
+++ b/src/scm/localReplicaSCM.ts
@@ -40,7 +40,6 @@ export class LocalReplicaSCMProvider extends BaseSCM {
     private baseCache: {[key:string]: Uint8Array} = {};
     private vfsWatcher?: vscode.FileSystemWatcher;
     private localWatcher?: vscode.FileSystemWatcher;
-    private saveListener?: vscode.Disposable;
     private ignorePatterns: string[] = [
         '**/.*',
         '**/.*/**',
@@ -376,24 +375,27 @@ export class LocalReplicaSCMProvider extends BaseSCM {
         );
         await this.overwrite();
 
-        // Listen for explicit user saves (not file system changes) to push local edits.
-        // File system watchers would also fire for git operations, compilation outputs,
-        // and other external modifications, causing unwanted sync (issues #299, #323).
-        this.saveListener = vscode.workspace.onDidSaveTextDocument(
-            doc => this.onDocumentSaved(doc)
-        );
+        const syncOnFileChange = vscode.workspace
+            .getConfiguration('overleaf-workshop.localReplica.syncOnFileChange')
+            .get<boolean>('enabled', false);
+
+        // By default, only explicit editor saves push file modifications. Users who
+        // rely on external tools can opt into file-system change events instead.
+        // Keep these listeners mutually exclusive so an editor save is not pushed twice.
+        const localChangeListener = syncOnFileChange
+            ? this.localWatcher.onDidChange(async uri => await this.syncToVFS(uri, 'update'))
+            : vscode.workspace.onDidSaveTextDocument(doc => this.onDocumentSaved(doc));
 
         return [
             // sync from vfs to local
             this.vfsWatcher.onDidChange(async uri => await this.syncFromVFS(uri, 'update')),
             this.vfsWatcher.onDidCreate(async uri => await this.syncFromVFS(uri, 'update')),
             this.vfsWatcher.onDidDelete(async uri => await this.syncFromVFS(uri, 'delete')),
-            // sync from local to vfs: file updates via editor saves (onDidSaveTextDocument above),
-            // file creation and deletion still via watcher (these are explicit user actions)
+            // sync from local to vfs: file updates use the configured listener above;
+            // file creation and deletion still always use the file-system watcher
+            localChangeListener,
             this.localWatcher.onDidCreate(async uri => await this.syncToVFS(uri, 'update')),
             this.localWatcher.onDidDelete(async uri => await this.syncToVFS(uri, 'delete')),
-            // include save listener for proper disposal
-            this.saveListener,
         ];
     }
 


### PR DESCRIPTION
## Changes

- Add the opt-in setting `overleaf-workshop.localReplica.syncOnFileChange.enabled`.
- Keep editor-save-based synchronization as the default behavior.
- When enabled, use `localWatcher.onDidChange` to detect modifications made by external tools.
- Keep the file-system listener and editor-save listener mutually exclusive to avoid handling the same editor save through both listeners.
- Keep the existing create and delete synchronization unchanged.

## Rationale

Commit `debdcb5` replaced file-system change events with `onDidSaveTextDocument` to prevent unwanted synchronization caused by Git operations and build tools (#299 and #323).

However, changes made outside the VS Code editor, such as edits from scripts or AI coding tools, no longer produce an editor-save event and therefore are not uploaded.

This change provides an explicit opt-in for users who need external-file synchronization while preserving the current safer behavior by default. When the option is enabled, changes made by Git or build tools may also be synchronized.

This PR only restores the missing external-file-change trigger. It does not change the `bypassCache`, OT conflict handling, or merge implementation. The Windows path comparison handled separately by #397 is also outside the scope of this PR.

## Testing

- `npm run compile` — passed
- `npm run lint` — passed with two pre-existing warnings
- `git diff --check` — passed
- Manually tested on Windows with a Local Replica project