### PR TITLE
fix(intellisense): clamp spell-check start line with Math.max

### DIFF
--- a/src/intellisense/langMisspellingCheckProvider.ts
+++ b/src/intellisense/langMisspellingCheckProvider.ts
@@ -227,7 +227,7 @@ export class MisspellingCheckProvider extends IntellisenseProvider implements vs
                     const uri = e.document.uri;
                     for (const event of e.contentChanges) {
                         // extract changed text
-                        const startLine = Math.min(0, event.range.start.line-1);
+                        const startLine = Math.max(0, event.range.start.line-1);
                         const [endLine, maxLength] = (() => {
                             try {
                                 const _line = event.range.end.line;


### PR DESCRIPTION
Fixes #402

## Problem

`MisspellingCheckProvider` computes the first line to re-check as:

```ts
const startLine = Math.min(0, event.range.start.line-1);
```

`Math.min(0, x)` is always `<= 0`, so:

- editing line 0 gives `startLine = -1`, and the `vscode.Range` constructor throws `Illegal argument: line must be non-negative` before `validateRange` gets a chance to clamp it;
- editing any other line gives `startLine = 0`, so the whole document from line 0 up to the edited line is re-checked instead of the intended one line of context.

The handler is an unawaited `async` callback, so the exception also shows up as `rejected promise not handled within 1 second` (visible in the logs attached to #194).

## Change

`Math.min` → `Math.max`, which is what the surrounding code intends: one line of context, clamped at the start of the document.
