### PR TITLE
fix(vfs): do not send an empty applyOtUpdate on save

### DIFF
--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -879,7 +879,12 @@ export class VirtualFileSystem extends vscode.Disposable {
                 })(),
             };
             this.isDirty = (update.op && update.op.length) ? true : false;
-            await this.socket.applyOtUpdate(doc._id, update);
+            // Skip the round-trip when the diff produced no operation (e.g. saving an
+            // unchanged document): the server has nothing to apply, answers with an error
+            // object and then force-disconnects the client 100ms later.
+            if (this.isDirty) {
+                await this.socket.applyOtUpdate(doc._id, update);
+            }
             doc.localCache = mergeRes;
             doc.remoteCache = mergeRes;
             setTimeout(() => {


### PR DESCRIPTION
Fixes #403

## Problem

`VirtualFileSystem.writeFile` sends the computed OT update unconditionally:

```ts
this.isDirty = (update.op && update.op.length) ? true : false;
await this.socket.applyOtUpdate(doc._id, update);
```

When the diff resolves to nothing (saving a document that did not really change), `update.op` is `[]` and the update is still emitted. The real-time service answers the emit with an error object and sends `forceDisconnect` shortly after, so:

- the raw payload reaches the user as `Failed to save 'main.tex': Unable to write file ... ([object Object])`;
- the socket is dropped, reconnects, the save is retried, and the loop repeats.

## Change

Skip the round-trip when the update carries no operation, reusing the `isDirty` flag computed on the line above. The local and remote caches are updated exactly as before, so a save with no changes is now a silent no-op.

## Verification

Against overleaf.com with 0.15.10 + this patch: repeated `Ctrl+S` on an unchanged document no longer produces an error or a disconnect, and a save that does change the text still reaches the server (`applyOtUpdate` → `ack` → `otUpdateApplied`, text updated live on overleaf.com).
