### PR TITLE
fix(socketio): send clientTracking.updatePosition without an ack

### DIFF
--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -432,6 +432,14 @@ export class SocketIOAPI {
      * @returns {Promise}
      */
     async updatePosition(doc_id:string, row:number, column:number) {
+        // Fire-and-forget, like the official frontend: it passes no acknowledgement
+        // callback here. Asking for an ack turns every cursor move into a promise that
+        // can only fail: the caller in ClientManager does not `catch` it, so a slow or
+        // missing ack produces a 5s timeout *and* an unhandled rejection.
+        if (this.scheme!=='Alt') {
+            this.socket.emit('clientTracking.updatePosition', {row, column, doc_id});
+            return;
+        }
         return this.emit('clientTracking.updatePosition', {row, column, doc_id})
             .then(() => {
                 return;


### PR DESCRIPTION
Fixes #404

## Problem

`updatePosition` emits `clientTracking.updatePosition` through the promisified `emit`, i.e. with an acknowledgement callback:

```ts
return this.emit('clientTracking.updatePosition', {row, column, doc_id})
    .then(() => { return; });
```

The official web frontend emits this event without an acknowledgement — it is a notification, and the server broadcasts `clientTracking.clientUpdated` to the other clients. Asking for an ack turns every cursor movement into a promise that can only fail, and the only caller (`ClientManager`) attaches no `.catch`, so each failure is logged twice: as a 5 s timeout and as `rejected promise not handled within 1 second`. While typing this happens several times per second.

## Change

Emit the event directly on the socket, with no acknowledgement callback. The `Alt` (HTTP) scheme keeps the previous path, since there `emit` is implemented as a request/response cycle and the promise is how the call completes.

## Verification

Against overleaf.com with 0.15.10 + this patch: cursor movements go out as `5:::{"name":"clientTracking.updatePosition",…}` (no ack id), the server still processes them and broadcasts `clientTracking.clientUpdated` back, and the log stays clean while typing. Tested with a single client, so the rendering of other collaborators' cursors was not exercised.
