### PR TITLE
fix(socketio): clear the 5s emit timer on acknowledgement

### DIFF
--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -8,6 +8,19 @@ function decodePackedUtf8(text: string): string {
     return Buffer.from(text, 'latin1').toString('utf-8');
 }
 
+/** Render an arbitrary socket.io error payload as readable text */
+function stringifyError(err:any): string {
+    if (err===null || err===undefined) { return String(err); }
+    if (typeof err === 'string') { return err; }
+    const parts = [err.name, err.code, err.message].filter(x => x!==undefined && x!==null);
+    try {
+        const json = JSON.stringify(err);
+        return parts.length && json==='{}' ? parts.join(': ') : json;
+    } catch {
+        return parts.length ? parts.join(': ') : String(err);
+    }
+}
+
 export interface UpdateUserSchema {
     id: string,
     user_id: string,
@@ -135,14 +148,29 @@ export class SocketIOAPI {
         }
         // create emit
         (this.socket.emit)[require('util').promisify.custom] = (event:string, ...args:any[]) => {
+            // The socket this call is bound to. `init()` replaces `this.socket` when the
+            // handshake scheme changes; anything emitted on the old socket can never be
+            // acknowledged, so its timeout is expected and must not be reported as a failure.
+            const socketAtEmit = this.socket;
+            let timer:any = undefined;
             const timeoutPromise = new Promise((_, reject) => {
-                setTimeout(() => {
+                timer = setTimeout(() => {
+                    if (this.socket===socketAtEmit) {
+                        console.error(`SocketIOAPI: '${event}' timed out after 5s`);
+                    }
                     reject('timeout');
                 }, 5000);
             });
             const waitPromise = new Promise((resolve, reject) => {
-                this.socket.emit(event, ...args, (err:any, ...data:any[]) => {
+                socketAtEmit.emit(event, ...args, (err:any, ...data:any[]) => {
+                    // The answer arrived: cancel the timeout. Without this a timer is left
+                    // pending for 5s after *every* successful call, and it still runs its
+                    // callback on an already-settled race.
+                    if (timer!==undefined) { clearTimeout(timer); }
                     if (err) {
+                        // Without this, a server-side error object reaches the user as the
+                        // useless `Unable to write file ... ([object Object])`.
+                        console.error(`SocketIOAPI: '${event}' rejected:`, stringifyError(err));
                         reject(err);
                     } else {
                         resolve(data);


### PR DESCRIPTION
Fixes #405

## Problem

The promisified `emit` starts a 5 s timer per call and never clears it:

```ts
const timeoutPromise = new Promise((_, reject) => {
    setTimeout(() => { reject('timeout'); }, 5000);   // never cleared
});
```

When the acknowledgement arrives the race is already settled, so the late `reject` is a no-op and nothing is visible — but a timer stays pending for 5 s after **every** emit and still runs its callback. On a path that runs continuously while editing (`joinDoc`, `applyOtUpdate`, `clientTracking.*`) that is one live timer per call, and it makes the timeout impossible to instrument: adding any log to that callback reports a failure for every *successful* call, 5 s late. That is exactly what happened while I was debugging this extension — the console filled with `'applyOtUpdate' timed out after 5s` for saves that had been acknowledged in ~150 ms and had already appeared on overleaf.com.

Two related points, both in the same few lines:

- `init()` replaces `this.socket` when the handshake scheme changes (v1 → v2 on overleaf.com). A call emitted on the previous socket can never be acknowledged, so its timer always fires even though the call was abandoned by design; binding the call to the socket it was emitted on tells the two cases apart.
- when the server rejects an emit, the raw payload is passed on and VS Code renders it as `Unable to write file ... ([object Object])`, hiding the actual message.

## Change

- `clearTimeout` in the acknowledgement callback;
- capture `socketAtEmit` and emit on it, so a timeout on a socket that has since been replaced is not reported as a failure;
- log a rejected emit through a small `stringifyError` helper (`name`/`code`/`message`, falling back to JSON), instead of letting `[object Object]` reach the user.

## Verification

Against overleaf.com with 0.15.10 + this patch, tracing socket.io 0.9 packets: every emit that asks for an ack (`5:<id>+::…`) gets its `ack ackId=<id>` back, and no timeout is logged any more — before the fix the same session produced ~20 spurious timeout lines. The one call that legitimately never completes (the `joinProject` queued on the v1 socket that overleaf.com rejects) is now silent instead of printing an error.
