### PR TITLE
fix: verify remote document saves after reconnecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -790,6 +790,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
+    "test:unit": "tsc -p ./ && mocha 'out/test/**/*.test.js'",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -75,7 +75,7 @@ export interface EventsHandler {
 type ConnectionScheme = 'Alt' | 'v1' | 'v2';
 
 export class SocketIOAPI {
-    private scheme: ConnectionScheme = 'v1';
+    private scheme: ConnectionScheme = 'v2';
     private record?: Promise<ProjectEntity>;
     private _handlers: Array<EventsHandler> = [];
     /** Track EventBus listeners for cleanup to prevent MaxListenersExceededWarning */
@@ -165,6 +165,10 @@ export class SocketIOAPI {
         return this._socketInitScheme !== this.scheme || !this.socket;
     }
 
+    get isConnected(): boolean {
+        return Boolean(this.socket?.socket?.connected);
+    }
+
     /** Clean up any accumulated EventBus listeners */
     private _cleanupEventBusListeners() {
         for (const cleanup of this._eventBusCleanups) {
@@ -227,7 +231,7 @@ export class SocketIOAPI {
     }
 
     toggleAlternativeConnectionScheme(url: string, updatedRecord?: ProjectEntity) {
-        this.scheme = this.scheme==='Alt' ? 'v1' : 'Alt';
+        this.scheme = this.scheme==='Alt' ? 'v2' : 'Alt';
         if (updatedRecord) {
             this.url = url;
             this.record = Promise.resolve(updatedRecord);

--- a/src/core/otUpdate.ts
+++ b/src/core/otUpdate.ts
@@ -1,0 +1,35 @@
+import * as crypto from 'crypto';
+import * as DiffMatchPatch from 'diff-match-patch';
+import { UpdateSchema } from '../api/socketio';
+
+export function mergeLocalChanges(baseContent: string, remoteContent: string, requestedContent: string): string {
+    const dmp = new DiffMatchPatch();
+    const remoteChanges = dmp.patch_make(baseContent, remoteContent);
+    return dmp.patch_apply(remoteChanges, requestedContent)[0] as string;
+}
+
+export function createOtUpdate(docId: string, version: number, remoteContent: string, content: string): UpdateSchema {
+    const dmp = new DiffMatchPatch();
+    let currentPos = 0;
+    const op = dmp.diff_main(remoteContent, content)
+        .map((part) => {
+            const incCount = part[0] === -1 ? 0 : part[1].length;
+            currentPos += incCount;
+            if (part[0] === 0) {
+                return undefined;
+            }
+            return {
+                p: currentPos - incCount,
+                i: part[0] === 1 ? part[1] : undefined,
+                d: part[0] === -1 ? part[1] : undefined,
+            };
+        })
+        .filter((part) => part !== undefined) as NonNullable<UpdateSchema['op']>;
+
+    return {
+        doc: docId,
+        v: version,
+        hash: crypto.createHash('sha1').update(`blob ${content.length}\x00${content}`).digest('hex'),
+        op,
+    };
+}

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as vscode from 'vscode';
-import * as DiffMatchPatch from 'diff-match-patch';
 import { BaseAPI, MemberEntity, ProjectSettingsSchema } from '../api/base';
 import { SocketIOAPI, UpdateSchema } from '../api/socketio';
 import { OUTPUT_FOLDER_NAME, ROOT_NAME } from '../consts';
@@ -9,6 +8,7 @@ import { ClientManager } from '../collaboration/clientManager';
 import { EventBus } from '../utils/eventBus';
 import { SCMCollectionProvider } from '../scm/scmCollectionProvider';
 import { ExtendedBaseAPI, ProjectLinkedFileProvider, UrlLinkedFileProvider } from '../api/extendedBase';
+import { createOtUpdate, mergeLocalChanges } from './otUpdate';
 
 const __OUTPUTS_ID = `${ROOT_NAME}-outputs`;
 
@@ -124,6 +124,7 @@ export class VirtualFileSystem extends vscode.Disposable {
     private lastDisconnectTime: number = 0;
     /** Whether event handlers have been registered on the current socket */
     private handlersRegistered: boolean = false;
+    private writeQueue: Promise<void> = Promise.resolve();
     private outputBuildId?: string;
     private compileGroup?: string;
     private clsiServerId?: string;
@@ -544,6 +545,9 @@ export class VirtualFileSystem extends vscode.Disposable {
                 } else {
                     doc.remoteCache = undefined;
                     doc.localCache = undefined;
+                    this.notify([
+                        {type: vscode.FileChangeType.Changed, uri: this.pathToUri(res.path)}
+                    ]);
                 }
             },
             onSpellCheckLanguageUpdated: (language:string) => {
@@ -819,6 +823,95 @@ export class VirtualFileSystem extends vscode.Disposable {
         ]);
     }
 
+    private async refreshDocument(uri: vscode.Uri): Promise<DocumentEntity> {
+        const {fileType, fileEntity} = await this._resolveUri(uri);
+        if (fileType!=='doc' || !fileEntity) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        const doc = fileEntity as DocumentEntity;
+        const snapshot = await this.socket.joinDoc(doc._id);
+        const remoteContent = snapshot.docLines.join('\n');
+        doc.version = snapshot.version;
+        doc.remoteCache = remoteContent;
+        doc.localCache = remoteContent;
+        return doc;
+    }
+
+    private async reconnectProject(): Promise<void> {
+        if (this.retryTimer) {
+            clearTimeout(this.retryTimer);
+            this.retryTimer = undefined;
+        }
+        this.lastDisconnectTime = 0;
+        this.socket.init();
+        await this.socket.joinProject(this.projectId);
+        this.retryConnection = 0;
+    }
+
+    private async writeDocument(uri: vscode.Uri, content: Uint8Array): Promise<void> {
+        const requestedContent = new TextDecoder().decode(content);
+        let baseContent: string | undefined;
+        let lastError: unknown;
+
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            try {
+                if (!this.socket.isConnected) {
+                    await this.reconnectProject();
+                }
+                let {fileType, fileEntity} = await this._resolveUri(uri);
+                if (fileType!=='doc' || !fileEntity) {
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                }
+                let doc = fileEntity as DocumentEntity;
+                if (doc.version===undefined || doc.localCache===undefined || doc.remoteCache===undefined) {
+                    doc = await this.refreshDocument(uri);
+                }
+
+                if (baseContent===undefined) {
+                    baseContent = doc.localCache!;
+                }
+                const mergedContent = mergeLocalChanges(baseContent, doc.remoteCache!, requestedContent);
+                const update = createOtUpdate(doc._id, doc.version!, doc.remoteCache!, mergedContent);
+                if (!update.op?.length) {
+                    doc.localCache = mergedContent;
+                    doc.remoteCache = mergedContent;
+                    return;
+                }
+
+                try {
+                    await this.socket.applyOtUpdate(doc._id, update);
+                } catch (error) {
+                    lastError = error;
+                    if (!this.socket.isConnected) {
+                        throw error;
+                    }
+                }
+
+                doc = await this.refreshDocument(uri);
+                if (doc.remoteCache===mergedContent) {
+                    this.isDirty = true;
+                    this.notify([
+                        {type: vscode.FileChangeType.Changed, uri}
+                    ]);
+                    return;
+                }
+                lastError = new Error('The server content did not match the saved document.');
+            } catch (error) {
+                lastError = error;
+            }
+
+            if (attempt===0) {
+                try {
+                    await this.reconnectProject();
+                } catch (error) {
+                    lastError = error;
+                }
+            }
+        }
+
+        throw vscode.FileSystemError.Unavailable(`Overleaf did not confirm the save: ${String(lastError)}`);
+    }
+
     async writeFile(uri: vscode.Uri, content:Uint8Array, create:boolean, overwrite:boolean) {
         const {fileType, fileEntity} = await this._resolveUri(uri);
 
@@ -834,60 +927,10 @@ export class VirtualFileSystem extends vscode.Disposable {
 
         // if exists and is doc --> update
         if (fileType && fileType==='doc' && fileEntity) {
-            const doc = fileEntity as DocumentEntity;
-            const _content = new TextDecoder().decode(content);
-            if (doc.version===undefined || doc.localCache===undefined || doc.remoteCache===undefined) {
-                return;
-            }
-            const dmp = new DiffMatchPatch();
-            const patches = dmp.patch_make(doc.localCache,  doc.remoteCache);
-
-            const mergeResArray = dmp.patch_apply(patches, _content);
-            const mergeRes = mergeResArray[0] as string;
-            const update = {
-                doc: doc._id,
-                lastV: doc.lastVersion,
-                v: doc.version,
-                // Reference: services/web/frontend/js/vendor/libs/sharejs.js#L1288
-                hash: (()=>{
-                    if (!doc.mtime || Date.now()-doc.mtime>5000) {
-                        doc.mtime = Date.now();
-                        return require('crypto').createHash('sha1').update(
-                            "blob " + mergeRes.length + "\x00" + mergeRes
-                        ).digest('hex');
-                    }
-                })() as string,
-                op: (()=>{
-                    const remoteCacheAscii = Buffer.from(doc.remoteCache, 'utf-8').toString('utf-8');
-                    const mergeResAscii = Buffer.from(mergeRes, 'utf-8').toString('utf-8');
-                    let currentPos = 0;
-                    return dmp.diff_main(remoteCacheAscii, mergeResAscii)
-                                .map((part) => {
-                                    // part[0] === -1: delete, 0: equal, 1: insert; part[1]: compared content
-                                    const incCount = part[0] === -1 ? 0 : part[1].length;
-                                    currentPos += incCount;
-                                    // add op when content not equal
-                                    if (part[0] !== 0) {
-                                        return {
-                                            p: currentPos - incCount,
-                                            i: part[0] ===  1 ?  part[1] : undefined,
-                                            d: part[0] === -1 ?  part[1] : undefined,
-                                        };
-                                    }
-                                })
-                                .filter(x => x) as any;
-                })(),
-            };
-            this.isDirty = (update.op && update.op.length) ? true : false;
-            await this.socket.applyOtUpdate(doc._id, update);
-            doc.localCache = mergeRes;
-            doc.remoteCache = mergeRes;
-            setTimeout(() => {
-                this.notify([
-                    {type: vscode.FileChangeType.Changed, uri: uri}
-                ]);
-            }, 10);
-            doc.lastVersion = doc.version;                
+            const write = this.writeQueue.catch(() => undefined)
+                .then(() => this.writeDocument(uri, content));
+            this.writeQueue = write.then(() => undefined, () => undefined);
+            return write;
         }
     }
 

--- a/src/test/otUpdate.test.ts
+++ b/src/test/otUpdate.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import { createOtUpdate, mergeLocalChanges } from '../core/otUpdate';
+
+function applyUpdate(content: string, op: NonNullable<ReturnType<typeof createOtUpdate>['op']>): string {
+    let result = content;
+    for (const part of op) {
+        if (part.i !== undefined) {
+            result = result.slice(0, part.p) + part.i + result.slice(part.p);
+        } else if (part.d !== undefined) {
+            result = result.slice(0, part.p) + result.slice(part.p + part.d.length);
+        }
+    }
+    return result;
+}
+
+describe('reliable Overleaf writes', () => {
+    it('preserves remote edits when applying a local save', () => {
+        const base = 'first\nsecond\n';
+        const remote = 'remote\nfirst\nsecond\n';
+        const requested = 'first\nsecond changed\n';
+
+        assert.strictEqual(mergeLocalChanges(base, remote, requested), 'remote\nfirst\nsecond changed\n');
+    });
+
+    it('builds an OT update that reproduces the requested content', () => {
+        const remote = 'alpha\nbeta\ngamma\n';
+        const requested = 'alpha\ninserted\ngamma changed\n';
+        const update = createOtUpdate('doc-id', 17, remote, requested);
+
+        assert.strictEqual(update.doc, 'doc-id');
+        assert.strictEqual(update.v, 17);
+        assert.ok(update.hash);
+        assert.strictEqual(applyUpdate(remote, update.op || []), requested);
+    });
+});


### PR DESCRIPTION
## Summary

- prefer the project-aware Socket.IO handshake while retaining the legacy fallback
- serialize remote document writes, refresh stale OT state, and retry one reconnect
- re-read the server snapshot and reject a save that the server did not confirm
- notify the virtual file system when OT versions diverge instead of leaving stale caches silent
- add focused unit tests for three-way merging and OT update generation

## Problem

When the collaboration socket becomes stale or the cached OT version diverges, a remote document write can time out or return without updating the server. The editor may then appear clean even though the remote document still contains the old content.

This change makes a save successful only after a fresh server snapshot matches the merged document. It also reconnects before writing when the underlying Socket.IO transport is disconnected.

Addresses #399.

## Validation

- `npm run compile`
- `npm run lint` (passes with two pre-existing warnings)
- `npm run test:unit` (2 passing)
- forced-disconnect round trip against Overleaf Cloud: the first save reconnected and matched a fresh server snapshot
- concurrent three-document save round trip: all writes and restorations matched fresh server snapshots

## Compatibility

The legacy v1 handshake remains available as a fallback. The reconnect path has been exercised against Overleaf Cloud; a self-hosted server that requires v1 was not available for manual testing.
