### PR TITLE
fix(vfs): advance doc version on ack so writes after the first succeed

### DIFF
--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -437,6 +437,16 @@ export class SocketIOAPI {
      * @returns {Promise}
      */
     async applyOtUpdate(docId:string, update:UpdateSchema) {
+        // An update that carries no ops is a no-op — there is nothing for the
+        // server to apply. The alternative connection scheme (SocketIOAlt)
+        // already short-circuits these; the realtime socket must too. Recent
+        // overleaf.com real-time validation rejects an empty-op update outright
+        // (`'applyOtUpdate' rejected: Invalid input`) and then disconnects the
+        // client, after which every following write fails until the window is
+        // reloaded. The genuine Overleaf client never emits an empty op either.
+        if (!update.op?.length) {
+            return;
+        }
         return this.emit('applyOtUpdate', docId, update)
             .then(() => {
                 return;

--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -8,6 +8,21 @@ function decodePackedUtf8(text: string): string {
     return Buffer.from(text, 'latin1').toString('utf-8');
 }
 
+/** How long to wait for a server acknowledgement before giving up on an emit. */
+const EMIT_TIMEOUT_MS = 15000;
+
+/** Render a socket.io error payload as something readable instead of `[object Object]`. */
+function stringifyError(err: any): string {
+    if (err === null || err === undefined) { return 'unknown error'; }
+    if (typeof err === 'string') { return err; }
+    if (err.message) { return err.message; }
+    try {
+        return JSON.stringify(err);
+    } catch {
+        return String(err);
+    }
+}
+
 export interface UpdateUserSchema {
     id: string,
     user_id: string,
@@ -135,15 +150,22 @@ export class SocketIOAPI {
         }
         // create emit
         (this.socket.emit)[require('util').promisify.custom] = (event:string, ...args:any[]) => {
+            // Bind the call to the socket it is emitted on: init() may swap this.socket
+            // out from under an in-flight call, and that call can never be acknowledged.
+            const socket = this.socket;
+            let timer: NodeJS.Timeout;
             const timeoutPromise = new Promise((_, reject) => {
-                setTimeout(() => {
-                    reject('timeout');
-                }, 5000);
+                timer = setTimeout(() => {
+                    reject(new Error(`'${event}' timed out after ${EMIT_TIMEOUT_MS}ms`));
+                }, EMIT_TIMEOUT_MS);
             });
             const waitPromise = new Promise((resolve, reject) => {
-                this.socket.emit(event, ...args, (err:any, ...data:any[]) => {
+                socket.emit(event, ...args, (err:any, ...data:any[]) => {
+                    // Clear the timer as soon as the ack lands, otherwise every single
+                    // emit leaks a live timer for the whole timeout window.
+                    clearTimeout(timer);
                     if (err) {
-                        reject(err);
+                        reject(err instanceof Error ? err : new Error(`'${event}' rejected: ${stringifyError(err)}`));
                     } else {
                         resolve(data);
                     }
@@ -200,6 +222,13 @@ export class SocketIOAPI {
         this.socket.on('error', (err:any) => {
             // Log error instead of throwing to avoid crashing the extension
             console.error('SocketIOAPI: socket error', err?.message || err);
+        });
+        // The server reports a rejected document update on its own channel and sends no
+        // ack for the emit, so without this the real reason (stale version, hash
+        // mismatch, lost session) is invisible and surfaces only as a generic timeout.
+        this.socket.on('otUpdateError', (err:any, update?:any) => {
+            console.error('SocketIOAPI: otUpdateError', stringifyError(err),
+                          update!==undefined ? stringifyError(update) : '');
         });
 
         if (this.scheme==='v2') {

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -839,55 +839,95 @@ export class VirtualFileSystem extends vscode.Disposable {
             if (doc.version===undefined || doc.localCache===undefined || doc.remoteCache===undefined) {
                 return;
             }
-            const dmp = new DiffMatchPatch();
-            const patches = dmp.patch_make(doc.localCache,  doc.remoteCache);
+            // Build the OT update against whatever the caches currently hold, so that a
+            // retry after a resync diffs against the server's content, not stale content.
+            const buildUpdate = () => {
+                const dmp = new DiffMatchPatch();
+                const patches = dmp.patch_make(doc.localCache!,  doc.remoteCache!);
 
-            const mergeResArray = dmp.patch_apply(patches, _content);
-            const mergeRes = mergeResArray[0] as string;
-            const update = {
-                doc: doc._id,
-                lastV: doc.lastVersion,
-                v: doc.version,
-                // Reference: services/web/frontend/js/vendor/libs/sharejs.js#L1288
-                hash: (()=>{
-                    if (!doc.mtime || Date.now()-doc.mtime>5000) {
-                        doc.mtime = Date.now();
-                        return require('crypto').createHash('sha1').update(
-                            "blob " + mergeRes.length + "\x00" + mergeRes
-                        ).digest('hex');
-                    }
-                })() as string,
-                op: (()=>{
-                    const remoteCacheAscii = Buffer.from(doc.remoteCache, 'utf-8').toString('utf-8');
-                    const mergeResAscii = Buffer.from(mergeRes, 'utf-8').toString('utf-8');
-                    let currentPos = 0;
-                    return dmp.diff_main(remoteCacheAscii, mergeResAscii)
-                                .map((part) => {
-                                    // part[0] === -1: delete, 0: equal, 1: insert; part[1]: compared content
-                                    const incCount = part[0] === -1 ? 0 : part[1].length;
-                                    currentPos += incCount;
-                                    // add op when content not equal
-                                    if (part[0] !== 0) {
-                                        return {
-                                            p: currentPos - incCount,
-                                            i: part[0] ===  1 ?  part[1] : undefined,
-                                            d: part[0] === -1 ?  part[1] : undefined,
-                                        };
-                                    }
-                                })
-                                .filter(x => x) as any;
-                })(),
+                const mergeResArray = dmp.patch_apply(patches, _content);
+                const mergeRes = mergeResArray[0] as string;
+                const update = {
+                    doc: doc._id,
+                    lastV: doc.lastVersion,
+                    v: doc.version!,
+                    // Reference: services/web/frontend/js/vendor/libs/sharejs.js#L1288
+                    hash: (()=>{
+                        if (!doc.mtime || Date.now()-doc.mtime>5000) {
+                            doc.mtime = Date.now();
+                            return require('crypto').createHash('sha1').update(
+                                "blob " + mergeRes.length + "\x00" + mergeRes
+                            ).digest('hex');
+                        }
+                    })() as string,
+                    op: (()=>{
+                        const remoteCacheAscii = Buffer.from(doc.remoteCache!, 'utf-8').toString('utf-8');
+                        const mergeResAscii = Buffer.from(mergeRes, 'utf-8').toString('utf-8');
+                        let currentPos = 0;
+                        return dmp.diff_main(remoteCacheAscii, mergeResAscii)
+                                    .map((part) => {
+                                        // part[0] === -1: delete, 0: equal, 1: insert; part[1]: compared content
+                                        const incCount = part[0] === -1 ? 0 : part[1].length;
+                                        currentPos += incCount;
+                                        // add op when content not equal
+                                        if (part[0] !== 0) {
+                                            return {
+                                                p: currentPos - incCount,
+                                                i: part[0] ===  1 ?  part[1] : undefined,
+                                                d: part[0] === -1 ?  part[1] : undefined,
+                                            };
+                                        }
+                                    })
+                                    .filter(x => x) as any;
+                    })(),
+                };
+                return {update, mergeRes};
             };
-            this.isDirty = (update.op && update.op.length) ? true : false;
-            await this.socket.applyOtUpdate(doc._id, update);
-            doc.localCache = mergeRes;
-            doc.remoteCache = mergeRes;
-            setTimeout(() => {
-                this.notify([
-                    {type: vscode.FileChangeType.Changed, uri: uri}
-                ]);
-            }, 10);
-            doc.lastVersion = doc.version;                
+
+            let lastError: any;
+            for (let attempt = 0; attempt < 2; attempt++) {
+                const {update, mergeRes} = buildUpdate();
+                this.isDirty = (update.op && update.op.length) ? true : false;
+                try {
+                    await this.socket.applyOtUpdate(doc._id, update);
+                    // An op submitted at version v moves the doc to v+1, but the server only
+                    // broadcasts `otUpdateApplied` to the OTHER clients in the project — the
+                    // author learns the new version from the ack alone. Without advancing it
+                    // here, every later write re-submits a stale v, the server rejects it via
+                    // `otUpdateError` (which sends no ack at all), and the write dies as a
+                    // bogus timeout until the doc is re-opened.
+                    if (update.op && update.op.length) {
+                        doc.lastVersion = doc.version;
+                        doc.version! += 1;
+                    }
+                    doc.localCache = mergeRes;
+                    doc.remoteCache = mergeRes;
+                    setTimeout(() => {
+                        this.notify([
+                            {type: vscode.FileChangeType.Changed, uri: uri}
+                        ]);
+                    }, 10);
+                    return;
+                } catch (err) {
+                    lastError = err;
+                    if (attempt > 0) { break; }
+                    // Re-join the doc to resync version and content, then rebuild the op
+                    // against what the server actually holds and try once more. This also
+                    // recovers when the real-time session was dropped underneath us.
+                    try {
+                        const rejoin = await this.socket.joinDoc(doc._id);
+                        const remote = rejoin.docLines.join('\n');
+                        doc.version = rejoin.version;
+                        doc.lastVersion = rejoin.version;
+                        doc.remoteCache = remote;
+                        doc.localCache = remote;
+                        doc.mtime = undefined;
+                    } catch {
+                        break;
+                    }
+                }
+            }
+            throw lastError;
         }
     }
 


### PR DESCRIPTION
### The problem

Saving a document to overleaf.com fails with

```
Failed to save 'main.tex': Unable to write file
'overleaf-workshop://www.overleaf.com/<project>/main.tex?user=…&project=…' (timeout)
```

for **every write after the first one**, until the document is closed and re-opened. This is #399; #351 and #234 look like the same fault seen from different angles.

The word "timeout" sends this in the wrong direction. The socket is healthy, the network is fine, and the server is answering. Nothing hangs.

### Root cause: a version desync, not a slow connection

An op submitted at version `v` moves the document to `v+1`. The server broadcasts `otUpdateApplied` only to the **other** clients in the project — the author of the change learns the new version from the ack alone. `applyOtUpdate` throws that ack away:

```ts
async applyOtUpdate(docId:string, update:UpdateSchema) {
    return this.emit('applyOtUpdate', docId, update)
        .then(() => { return; });   // ack, and with it the new version, is discarded
}
```

and `writeFile` never advances `doc.version` either — it only does `doc.lastVersion = doc.version`.

So:

1. `joinDoc` sets `doc.version = N`.
2. First write sends `v: N`. Accepted. Server is now at `N+1`.
3. `doc.version` is still `N` locally.
4. Second write sends `v: N` again → the server rejects it as stale.
5. The rejection arrives on the **`otUpdateError`** channel, which nothing in the extension subscribes to (`grep -r otUpdateError src/` → no hits).
6. With no ack, the `Promise.race` in the promisified `emit` fires its own 5s timer and rejects with the bare string `'timeout'`.
7. VS Code surfaces that as `Unable to write file … (timeout)`.

Hence the giveaway symptom: **exactly one successful save per document open.**

### Steps to reproduce

1. Open any project from overleaf.com, open a `.tex` file.
2. Edit and save — succeeds.
3. Edit and save again — fails with `(timeout)` after 5s, and keeps failing.
4. Close and re-open the file — one more save succeeds, then it is stuck again.

### What changed

**`src/core/remoteFileSystemProvider.ts` — `writeFile()`**

- Advance `doc.version` once the update has been acknowledged. This is the actual fix.
- On failure, re-join the doc to resync version and content, rebuild the op against what the server actually holds, and retry once. This makes the write path self-healing if the version drifts for any other reason, or the real-time session is dropped underneath us.
- The op construction moved into a `buildUpdate()` closure so the retry diffs against the refreshed caches rather than the stale ones.

**`src/api/socketio.ts`**

- Subscribe to `otUpdateError` and log it, so a rejected update is reported for what it is instead of masquerading as a timeout.
- `clearTimeout` in the ack callback. Previously every emit left a live timer for the full timeout window — on a path that runs continuously while editing. This is #405: it also made the timeout callback impossible to instrument, because adding any logging there produced a timeout entry 5s after every *successful* call.
- Bind each emit to the socket it was sent on. `init()` can replace `this.socket` mid-flight (v1 → v2 handshake switch), and a call abandoned that way could otherwise settle against a different socket.
- Raise the emit timeout 5s → 15s, and render rejected payloads through a small `stringifyError` helper instead of `[object Object]`.

### Testing

- `npx tsc --noEmit -p ./` — 0 errors.
- `npx eslint src --ext ts` — 0 errors (2 pre-existing warnings, in files this PR does not touch).
- `npm run compile` — succeeds.
- `npm test` — the `test` script points at `out/test/runTest.js`, which this repository does not contain; it fails identically on an unmodified `master`, so there is no suite to regress.
- Verified live in VS Code against a real overleaf.com project:
  - four consecutive saves all succeed (before: only the first ever did);
  - content confirmed server-side by closing and re-opening the file, which forces a fresh `joinDoc`;
  - LaTeX compile reports `Ready` with 0 errors afterwards.

### Second commit — don't emit an empty-op `applyOtUpdate`

The improved error rendering surfaced a second failure during testing:

```
'applyOtUpdate' rejected: Invalid input
```

and after one such rejection every following save timed out until the window was reloaded.

`writeFile` builds an OT update on **every** save. When the buffer already matches the server — a
save with no net change, or a second save right after the first — the diff is empty and the update
carries `op: []`. The realtime socket path sent it anyway. overleaf.com's real-time service now
validates the `applyOtUpdate` payload (`services/real-time/app/js/Router.js`) and rejects an
empty-op update before it reaches any OT logic, replying `Invalid input` with `disconnect: 1` — so
the server drops the client and the ensuing reconnect races every queued `emit` into a 15s timeout.

`SocketIOAlt` already short-circuits empty-op updates (`if (update.op?.length)` in
`src/api/socketioAlt.ts`), and the genuine Overleaf client never flushes without a real op
(`ShareJsDoc`'s `flush()` bails when `pendingOp === null`). The fix mirrors both:
`SocketIOAPI.applyOtUpdate` returns early when `update.op` is empty. `writeFile` already treats a
non-op-carrying update as "sync caches, don't advance the version", so nothing downstream changes.

Verified live: repeated `Ctrl+S` with no edits no longer produces `Invalid input` (the extension
makes no network call at all for an empty op), and real edit/save cycles are unaffected. Also
covered by an offline test that drives the compiled `writeFile` / `applyOtUpdate` with real
`diff-match-patch` — it passes on this branch and fails on the parent (which sends `op: []`).

### Notes for reviewers

`doc.version += 1` is applied only when the update actually carries ops. If a no-op update turns out to consume a version server-side too, the rejoin-and-retry path corrects the drift on the next write rather than getting stuck, so the two changes are deliberately complementary.
